### PR TITLE
Check if node "arguments" exists before calling getNode (Fixes #119)

### DIFF
--- a/src/TwigJs/Compiler/Expression/GetAttrCompiler.php
+++ b/src/TwigJs/Compiler/Expression/GetAttrCompiler.php
@@ -57,7 +57,7 @@ class GetAttrCompiler implements TypeCompilerInterface
             ->subcompile($node->getNode('attribute'))
         ;
 
-        $defaultArguments = 0 === count($node->getNode('arguments'));
+        $defaultArguments = 0 === count($node->hasNode('arguments') ? $node->getNode('arguments') : null);
         $defaultAccess = \Twig_TemplateInterface::ANY_CALL === $node->getAttribute('type');
         $defaultTest = false == $node->getAttribute('is_defined_test');
 

--- a/src/TwigJs/Compiler/Expression/Test/NullCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/NullCompiler.php
@@ -27,7 +27,7 @@ class NullCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );


### PR DESCRIPTION
Bring this PR into our fork - https://github.com/schmittjoh/twig.js/pull/120